### PR TITLE
#6 fixed database name parameter in TableExists method.

### DIFF
--- a/src/ClickHouse.Net/ClickHouseDatabase.cs
+++ b/src/ClickHouse.Net/ClickHouseDatabase.cs
@@ -94,7 +94,7 @@ namespace ClickHouse.Net
         {
             return Execute(cmd =>
             {
-                cmd.AddParameter("database", _connectionSettings.Database);
+                cmd.AddParameter("database", _connection.Database);
                 cmd.AddParameter("table", tableName);
                 return ExecuteExists(cmd);
             }, "SELECT COUNT(*) FROM system.tables WHERE database=@database AND name=@table");


### PR DESCRIPTION
#6 fixed database name parameter in TableExists method. This led to the incorrect result of method TableExists if database was changed after creating connection.